### PR TITLE
cd-traverse: iterate on cd **pattern by depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ real directories to special commands; so if you had a directory called `foo:`,
 
     $ cd machine-name:[path]    # automounts machine-name:path with sshfs
     $ cd /dev/sdb1              # create a mountpoint, then sudo-mount it
-    $ cd **foo                  # cd's to the first 'foo' descendant dir
+    $ cd **x                    # cd's to the first descendant dir matching /x/
     $ cd ..5                    # cd's up five directories
-    $ cd ..foo                  # cd's up to the nearest 'foo'
+    $ cd ..foo                  # cd's up to the nearest dir matching /foo/
     $ cd x.tar                  # mounts x.tar with archivemount
     $ cd hdfs://namenode:9000   # mounts namenode with hadoop-fuse-dfs
     $ cd ^                      # history: go back one directory

--- a/cd-traverse
+++ b/cd-traverse
@@ -32,22 +32,25 @@ function cd_traverse_ancestor {
 }
 
 function cd_traverse_descendant {
-  echo "cd: searching for descendants named '${1#\*\*}'..."
+  local pattern="${1#\*\*}"
+  local depth=1
+  local dirs dir
 
-  local name=${1#\*\*}
-  if [[ "${name%/}" != "$name" ]]; then
-    local dir_constraint='-type d'
-  fi
+  while : ; do
+    dirs="$(find -mindepth $depth -maxdepth $depth -type d 2>/dev/null)"
 
-  local destination=$(find . -name "$name" $dir_constraint -print -quit)
-  if [[ -n "$destination" ]]; then
-    if [[ -d "$destination" ]]; then
-      cd_goto "$destination"
-    else
-      cd_goto "${destination%/*}"
+    if test -z "$dirs" ; then
+      echo "cd: no descendant matches '${pattern}'"
+      return 1
     fi
-  else
-    echo "cd: no descendant matches '${1#\*\*}'"
-    return 1
-  fi
+
+    while read dir ; do
+      if [[ "$dir" =~ $pattern ]] ; then
+        cd_goto "$dir"
+        return
+      fi
+    done <<< "$dirs"
+
+    depth=$((depth + 1))
+  done
 }


### PR DESCRIPTION
This patch makes the cd_traverse_descendant function iterate by level, instead of full directory trees. This is more fast and convenient with huge file hierarchy, as we rarely want to go very deep.

I have several huge trees (such as kernel repositories), and for instance, cd'ing into ~/projects/tinycc took me 0m1.966s while it now takes 0m0.033s (real time, using the time command).

It also interprets the argument as a pattern, for consistency with cd_traverse_ancestor.

An example of usage with the pattern:

```
$ cd **cc && echo $PWD && cd -
/home/vivien/projects/tinycc

$ cd **/cc && echo $PWD && cd -
/home/vivien/projects/openwrt/tools/ccache

$ cd **/cc$ && echo $PWD && cd -
/home/vivien/projects/cd/.git/objects/cc
```
