### PR TITLE
cd: check that a glob match is successful

### DIFF
--- a/cd
+++ b/cd
@@ -303,6 +303,8 @@ function cd_lsof_mountpoints {
 function cd_clean_mountpoints {
   local still_waiting=0
   for mountpoint in ~/.cd/mountpoints/*; do
+    [[ -e $mountpoint ]] || break
+
     # The ! -e check is for wonky FUSE mounts that have gotten into an
     # inconsistent state.
     if [[ ! -e "$mountpoint" || -d "$mountpoint" ]]; then


### PR DESCRIPTION
Globs that match nothing expand to themselves. This causes `cd --clean`
to have this unwanted behavior:

```
~ $ cd --mounts
~ $ cd --clean
cd: unmounting *... still in use; not unmounting
```

See: http://mywiki.wooledge.org/NullGlob
